### PR TITLE
fix: bump node version due to deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ outputs:
       The returned Grafana Annotation ID that can be used to set and end time to
       the annotation after an action has completed.
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: anchor


### PR DESCRIPTION
Node 16 has officially been deprecated, so we need to run this on node20